### PR TITLE
fixed ui of Learn More button in dark mode on home page

### DIFF
--- a/MindVault-FE/src/components/Hero.tsx
+++ b/MindVault-FE/src/components/Hero.tsx
@@ -34,7 +34,12 @@ const Hero = () => {
               <ArrowRight className="ml-2 h-5 w-5" />
             </Link>
           </Button>
-          <Button variant="outline" size="lg" className="text-lg px-8 py-4 rounded-full border-2" asChild>
+          <Button 
+            variant="outline" 
+            size="lg" 
+            className="text-lg px-8 py-4 rounded-full border-2 hover:bg-white hover:text-black dark:hover:bg-white dark:hover:text-black" 
+            asChild
+          >
             <Link to="/about">Learn More</Link>
           </Button>
         </div>


### PR DESCRIPTION
Fixed #17
Fixed the Learn More button ui upon hovering on it in dark theme.

**Earlier:-**
<img width="1793" height="917" alt="image" src="https://github.com/user-attachments/assets/02749770-298b-4f35-91d7-7ae601eb5be0" />


**After my fix:-**
<img width="1832" height="842" alt="image" src="https://github.com/user-attachments/assets/be6d8715-62f8-4dc3-a739-8aeb6e3138b7" />
 
@ayushsoni02 request to please accept this PR if everything is fine. Also please tag this issue with some level(maybe level 1 or 2) because this is my contribution under gssoc so I need points for it which I will get if issue has been tagged with some level.
Thanks